### PR TITLE
output 'external' Security Group

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "vpn_sg_id" {
   value = "${aws_security_group.sg_wireguard_admin.id}"
   description = "ID of the internal Security Group to associate with other resources needing to be accessed on VPN."
 }
+
+output "vpn_external_sg_id" {
+  value = "${aws_security_group.sg_wireguard_external.id}"
+  description = "ID of the ('external') Security Group applied to the VPN."
+}


### PR DESCRIPTION
This allows it to be referenced by other Security Groups (in our current case, the Redshift Security Group).